### PR TITLE
Fixed calendar spacing issue

### DIFF
--- a/src/views/Calendar/Calendar.js
+++ b/src/views/Calendar/Calendar.js
@@ -28,7 +28,7 @@ const CalendarSchedule = () => {
 
     return (
         <>
-            <div style={{width: "100%", display: "flex", justifyContent: 'center', alignItems: 'center', height: "calc(100vh - 100px)"}}>
+            <div style={{width: "100%", display: "flex", marginTop: "50px", justifyContent: 'center', alignItems: 'center', height: "calc(100vh - 100px)"}}>
                     <Calendar 
                     className="calendar"
                     mode="month"                     


### PR DESCRIPTION
Fixed Issue on calendar screen where h1 was overlapping the logo of the page.

(First of other changes, I'm still getting used to the project eviornment)